### PR TITLE
change the namespace from core to entities

### DIFF
--- a/GitInsight.Api/Usings.cs
+++ b/GitInsight.Api/Usings.cs
@@ -1,12 +1,6 @@
-global using System.Reflection;
-
 global using Microsoft.AspNetCore.Authentication.JwtBearer;
 global using Microsoft.EntityFrameworkCore;
 global using Microsoft.Identity.Web;
-global using Microsoft.Identity.Web.Resource;
 
-
-global using GitInsight.Core;
 global using GitInsight.Entities;
-global using GitInsight;
 global using GitInsight.Api;

--- a/GitInsight.Entities/AuthorDTO.cs
+++ b/GitInsight.Entities/AuthorDTO.cs
@@ -1,4 +1,4 @@
-namespace GitInsight.Core;
+namespace GitInsight.Entities;
 
 public record AuthorDTO(int Id, string Name, ICollection<int> AllCommits);
 public record AuthorCreateDTO([StringLength(100)] string Name, ICollection<int> AllCommits);

--- a/GitInsight.Entities/AuthorRepository.cs
+++ b/GitInsight.Entities/AuthorRepository.cs
@@ -1,5 +1,4 @@
 namespace GitInsight.Entities;
-using GitInsight.Core;
 
 public class AuthorRepository : IAuthorRepository
 {

--- a/GitInsight.Entities/AuthorResult.cs
+++ b/GitInsight.Entities/AuthorResult.cs
@@ -1,4 +1,4 @@
-namespace GitInsight.Core;
+namespace GitInsight.Entities;
 
 public class AuthorResult
 {

--- a/GitInsight.Entities/CommitDTO.cs
+++ b/GitInsight.Entities/CommitDTO.cs
@@ -1,4 +1,4 @@
-namespace GitInsight.Core;
+namespace GitInsight.Entities;
 
 public record CommitDTO(int Id, int RepoId, string AuthorName, DateTime Date);
 public record CommitCreateDTO(int RepoID, string AuthorName, DateTime Date);

--- a/GitInsight.Entities/CommitRepository.cs
+++ b/GitInsight.Entities/CommitRepository.cs
@@ -1,5 +1,4 @@
 namespace GitInsight.Entities;
-using GitInsight.Core;
 
 public class CommitRepository : ICommitRepository
 {

--- a/GitInsight.Entities/FrequencyResult.cs
+++ b/GitInsight.Entities/FrequencyResult.cs
@@ -1,4 +1,4 @@
-namespace GitInsight.Core;
+namespace GitInsight.Entities;
 
 public class FrequencyResult
 {

--- a/GitInsight.Entities/IAuthorRepository.cs
+++ b/GitInsight.Entities/IAuthorRepository.cs
@@ -1,4 +1,4 @@
-namespace GitInsight.Core;
+namespace GitInsight.Entities;
 
 public interface IAuthorRepository
 {

--- a/GitInsight.Entities/ICommitRepository.cs
+++ b/GitInsight.Entities/ICommitRepository.cs
@@ -1,4 +1,4 @@
-namespace GitInsight.Core;
+namespace GitInsight.Entities;
 
 public interface ICommitRepository
 {

--- a/GitInsight.Entities/IRepoRepository.cs
+++ b/GitInsight.Entities/IRepoRepository.cs
@@ -1,4 +1,4 @@
-namespace GitInsight.Core;
+namespace GitInsight.Entities;
 
 public interface IRepoRepository
 {

--- a/GitInsight.Entities/RepoDTO.cs
+++ b/GitInsight.Entities/RepoDTO.cs
@@ -1,4 +1,4 @@
-namespace GitInsight.Core;
+namespace GitInsight.Entities;
 
 public record RepoDTO(int Id, [StringLength(100)] string Name, int LatestCommit, ICollection<int> AllCommits, AuthorResult? AuthorResult, FrequencyResult? FrequencyResult);
 public record RepoCreateDTO([StringLength(100)] string Name, ICollection<int> AllCommits);

--- a/GitInsight.Entities/RepoRepository.cs
+++ b/GitInsight.Entities/RepoRepository.cs
@@ -1,6 +1,4 @@
 namespace GitInsight.Entities;
-using GitInsight.Core;
-
 public class RepoRepository : IRepoRepository
 {
 

--- a/GitInsight.Entities/Response.cs
+++ b/GitInsight.Entities/Response.cs
@@ -1,4 +1,4 @@
-namespace GitInsight.Core;
+namespace GitInsight.Entities;
 
 public enum Response
 {

--- a/GitInsight.Entities/Using.cs
+++ b/GitInsight.Entities/Using.cs
@@ -1,5 +1,0 @@
-global using Microsoft.EntityFrameworkCore;
-global using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
-global using System.ComponentModel.DataAnnotations;
-
-global using GitInsight.Core;

--- a/GitInsight.Entities/Usings.cs
+++ b/GitInsight.Entities/Usings.cs
@@ -1,1 +1,4 @@
+global using Microsoft.EntityFrameworkCore;
+global using System.ComponentModel.DataAnnotations;
+
 global using System.ComponentModel.DataAnnotations;

--- a/GitInsight.Tests/AuthorRepositoryTests.cs
+++ b/GitInsight.Tests/AuthorRepositoryTests.cs
@@ -1,4 +1,4 @@
-namespace GitInsight.Entities.Tests;
+namespace GitInsight.Tests;
 
 public sealed class AuthorRepositoryTests : IDisposable
 {

--- a/GitInsight.Tests/CommitRepositoryTests.cs
+++ b/GitInsight.Tests/CommitRepositoryTests.cs
@@ -1,4 +1,4 @@
-namespace GitInsight.Entities.Tests;
+namespace GitInsight.Tests;
 
 public sealed class CommitRepositoryTests : IDisposable
 {

--- a/GitInsight.Tests/RepoRepositoryTests.cs
+++ b/GitInsight.Tests/RepoRepositoryTests.cs
@@ -1,4 +1,4 @@
-namespace GitInsight.Entities.Tests;
+namespace GitInsight.Tests;
 
 public sealed class RepoRepositoryTests : IDisposable
 {

--- a/GitInsight.Tests/Usings.cs
+++ b/GitInsight.Tests/Usings.cs
@@ -3,4 +3,3 @@ global using FluentAssertions;
 global using Microsoft.EntityFrameworkCore;
 global using GitInsight.Entities;
 global using Microsoft.Data.Sqlite;
-global using GitInsight.Core;

--- a/GitInsight/Using.cs
+++ b/GitInsight/Using.cs
@@ -1,4 +1,3 @@
-global using GitInsight.Core;
 global using GitInsight.Entities;
 global using LibGit2Sharp;
 global using LibGit2Sharp.Handlers;


### PR DESCRIPTION
This will clean up unused usings statements,
and change the namespace to reflect the new package structure